### PR TITLE
Alias Sampling

### DIFF
--- a/benchmarks/bench_gauss.c
+++ b/benchmarks/bench_gauss.c
@@ -71,6 +71,7 @@ const char *alg_to_str(dgs_disc_gauss_alg_t alg) {
   case DGS_DISC_GAUSS_UNIFORM_ONLINE: return "uniform+online";
   case DGS_DISC_GAUSS_UNIFORM_LOGTABLE: return "uniform+logtable";
   case DGS_DISC_GAUSS_SIGMA2_LOGTABLE: return "sigma2+logtable";
+  case DGS_DISC_GAUSS_ALIAS:           return "alias";
   default: return "unknown";
   }
 }

--- a/dgs/dgs_gauss.h
+++ b/dgs/dgs_gauss.h
@@ -112,6 +112,7 @@
 
 #define DGS_DISC_GAUSS_EQUAL_DIFF 0.001
 
+#define DGS_DISC_GAUSS_STRONG_EQUAL_DIFF pow(2, -45)
 /**
    Available Algorithms
 */
@@ -122,7 +123,7 @@ typedef enum {
   DGS_DISC_GAUSS_UNIFORM_TABLE     = 0x2, //<call dgs_disc_gauss_mp_call_uniform_table
   DGS_DISC_GAUSS_UNIFORM_LOGTABLE  = 0x3, //<call dgs_disc_gauss_mp_call_uniform_logtable
   DGS_DISC_GAUSS_SIGMA2_LOGTABLE   = 0x7, //<call dgs_disc_gauss_mp_call_sigma2_logtable
-  DGS_DISC_GAUSS_ALIAS             = 0x8,
+  DGS_DISC_GAUSS_ALIAS             = 0x8, //<call dgs_disc_gauss_mp_call_alias
 } dgs_disc_gauss_alg_t;
 
 /**
@@ -303,6 +304,13 @@ typedef struct _dgs_disc_gauss_dp_t {
   */
 
   double *rho;
+  
+  /**
+   * Tables required for alias sampling.
+   */
+   
+  long* alias;
+  dgs_bern_dp_t** bias;
 } dgs_disc_gauss_dp_t;
 
 /**

--- a/dgs/dgs_gauss.h
+++ b/dgs/dgs_gauss.h
@@ -122,6 +122,7 @@ typedef enum {
   DGS_DISC_GAUSS_UNIFORM_TABLE     = 0x2, //<call dgs_disc_gauss_mp_call_uniform_table
   DGS_DISC_GAUSS_UNIFORM_LOGTABLE  = 0x3, //<call dgs_disc_gauss_mp_call_uniform_logtable
   DGS_DISC_GAUSS_SIGMA2_LOGTABLE   = 0x7, //<call dgs_disc_gauss_mp_call_sigma2_logtable
+  DGS_DISC_GAUSS_ALIAS             = 0x8,
 } dgs_disc_gauss_alg_t;
 
 /**
@@ -352,6 +353,7 @@ long dgs_disc_gauss_dp_call_uniform_table(dgs_disc_gauss_dp_t *self);
 
 long dgs_disc_gauss_dp_call_uniform_table_offset(dgs_disc_gauss_dp_t *self);
 
+long dgs_disc_gauss_dp_call_alias(dgs_disc_gauss_dp_t *self);
 
 /**
   Sample from ``dgs_disc_gauss_dp_t`` by rejection sampling using the uniform
@@ -562,6 +564,8 @@ void dgs_disc_gauss_mp_call_uniform_table(mpz_t rop, dgs_disc_gauss_mp_t *self, 
  */
 
 void dgs_disc_gauss_mp_call_uniform_table_offset(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_randstate_t state);
+
+void dgs_disc_gauss_mp_call_alias(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_randstate_t state);
 
 /**
   Sample from ``dgs_disc_gauss_mp_t`` by rejection sampling using the uniform

--- a/dgs/dgs_gauss.h
+++ b/dgs/dgs_gauss.h
@@ -361,6 +361,13 @@ long dgs_disc_gauss_dp_call_uniform_table(dgs_disc_gauss_dp_t *self);
 
 long dgs_disc_gauss_dp_call_uniform_table_offset(dgs_disc_gauss_dp_t *self);
 
+/**
+   Sample from ``dgs_disc_gauss_dp_t`` by alias sampling. This is extremely fast, 
+   but requires more resources and setup cost is around (2τσ)².
+
+   :param self: discrete Gaussian sampler
+ */
+
 long dgs_disc_gauss_dp_call_alias(dgs_disc_gauss_dp_t *self);
 
 /**
@@ -539,6 +546,13 @@ typedef struct _dgs_disc_gauss_mp_t {
   */
 
   mpfr_t *rho;
+  
+    /**
+   * Tables required for alias sampling.
+   */
+   
+  mpz_t* alias;
+  dgs_bern_mp_t** bias;
 
 } dgs_disc_gauss_mp_t;
 
@@ -573,6 +587,12 @@ void dgs_disc_gauss_mp_call_uniform_table(mpz_t rop, dgs_disc_gauss_mp_t *self, 
 
 void dgs_disc_gauss_mp_call_uniform_table_offset(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_randstate_t state);
 
+/**
+   Sample from ``dgs_disc_gauss_mp_t`` by alias sampling. This is extremely fast, 
+   but requires more resources and setup cost is around (2τσ)².
+
+   :param self: discrete Gaussian sampler
+ */
 void dgs_disc_gauss_mp_call_alias(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_randstate_t state);
 
 /**

--- a/dgs/dgs_gauss_dp.c
+++ b/dgs/dgs_gauss_dp.c
@@ -159,6 +159,11 @@ dgs_disc_gauss_dp_t *dgs_disc_gauss_dp_init(double sigma, double c, size_t tau, 
     break;
   }
 
+  case DGS_DISC_GAUSS_ALIAS: {
+    dgs_die("not implemented");
+    break;
+  }
+  
   default:
     dgs_disc_gauss_dp_clear(self);
     dgs_die("unknown algorithm %d", algorithm);
@@ -201,6 +206,10 @@ long dgs_disc_gauss_dp_call_uniform_table_offset(dgs_disc_gauss_dp_t *self) {
   } while (y >= self->rho[x]);
 
   return x + self->c_z - self->upper_bound_minus_one;
+}
+
+long dgs_disc_gauss_dp_call_alias(dgs_disc_gauss_dp_t *self) {
+  dgs_die("not implemented");
 }
 
 long dgs_disc_gauss_dp_call_uniform_logtable(dgs_disc_gauss_dp_t *self) {

--- a/dgs/dgs_gauss_dp.c
+++ b/dgs/dgs_gauss_dp.c
@@ -214,6 +214,9 @@ dgs_disc_gauss_dp_t *dgs_disc_gauss_dp_init(double sigma, double c, size_t tau, 
     self->bias = (dgs_bern_dp_t**)malloc(sizeof(dgs_bern_dp_t*)*self->two_upper_bound_minus_one);
     
     // simple robin hood strategy approximates good alias
+    // this precomputation takes ~n^2, but could be reduced by 
+    // using better data structures to compute min and max 
+    // (instead of just linear search each time)
     double avg = 1.0 / ((double)self->two_upper_bound_minus_one);
     long low = _dgs_disc_gauss_dp_min_in_rho(self);
     long high;

--- a/dgs/dgs_gauss_dp.c
+++ b/dgs/dgs_gauss_dp.c
@@ -41,6 +41,42 @@ static inline void _dgs_disc_gauss_dp_init_bexp(dgs_disc_gauss_dp_t *self, doubl
   self->Bexp = dgs_bern_exp_dp_init(self->f, l);
 }
 
+static inline void _dgs_disc_gauss_dp_init_rho(dgs_disc_gauss_dp_t *self) {
+  self->rho = (double*)malloc(sizeof(double)*self->two_upper_bound_minus_one);
+  if (!self->rho){
+    dgs_disc_gauss_dp_clear(self);
+    dgs_die("out of memory");
+  }
+  long absmax = self->upper_bound_minus_one;
+  for(long x=-absmax; x<=absmax; x++) {
+    self->rho[x+self->upper_bound_minus_one] = exp( (((double)x) - self->c_r) * (((double)x) - self->c_r) * self->f);
+  }
+}
+
+static inline long _dgs_disc_gauss_dp_min_in_rho(dgs_disc_gauss_dp_t *self) {
+  long mi = 0;
+  double m = self->rho[mi];
+  for (long x = 1; x < self->two_upper_bound_minus_one;++x) {
+    if (self->rho[x] < m) {
+      mi = x;
+      m = self->rho[mi];
+    }
+  }
+  return mi;
+}
+
+static inline long _dgs_disc_gauss_dp_max_in_rho(dgs_disc_gauss_dp_t *self) {
+  long mi = 0;
+  double m = self->rho[mi];
+  for (long x = 1; x < self->two_upper_bound_minus_one;++x) {
+    if (self->rho[x] > m) {
+      mi = x;
+      m = self->rho[mi];
+    }
+  }
+  return mi;
+}
+
 dgs_disc_gauss_dp_t *dgs_disc_gauss_dp_init(double sigma, double c, size_t tau, dgs_disc_gauss_alg_t algorithm) {
   if (sigma <= 0.0)
     dgs_die("sigma must be > 0");
@@ -110,15 +146,7 @@ dgs_disc_gauss_dp_t *dgs_disc_gauss_dp_init(double sigma, double c, size_t tau, 
       self->rho[0]/= 2.0;
     } else {
       self->call = dgs_disc_gauss_dp_call_uniform_table_offset;
-      self->rho = (double*)malloc(sizeof(double)*self->two_upper_bound_minus_one);
-      if (!self->rho){
-        dgs_disc_gauss_dp_clear(self);
-        dgs_die("out of memory");
-      }
-      long absmax = self->upper_bound_minus_one;
-      for(long x=-absmax; x<=absmax; x++) {
-        self->rho[x+self->upper_bound_minus_one] = exp( (((double)x) - self->c_r) * (((double)x) - self->c_r) * self->f);
-      }
+      _dgs_disc_gauss_dp_init_rho(self);
     }
     break;
 
@@ -160,7 +188,46 @@ dgs_disc_gauss_dp_t *dgs_disc_gauss_dp_init(double sigma, double c, size_t tau, 
   }
 
   case DGS_DISC_GAUSS_ALIAS: {
-    dgs_die("not implemented");
+    self->call = dgs_disc_gauss_dp_call_alias;
+
+    upper_bound = ceil(self->sigma*tau) + 1;
+    self->upper_bound = upper_bound;
+    self->upper_bound_minus_one = upper_bound - 1;
+    self->two_upper_bound_minus_one = 2*upper_bound - 1;
+    self->B = dgs_bern_uniform_init(0);
+    self->f = -1.0/(2.0*(sigma*sigma));
+    
+    _dgs_disc_gauss_dp_init_rho(self);
+    
+    // convert rho to probabilities
+    double sum = 0;
+    for(long x=0; x<self->two_upper_bound_minus_one; x++) {
+      sum += self->rho[x];
+    }
+    sum = 1/sum;
+    for(long x=0; x<self->two_upper_bound_minus_one; x++) {
+      self->rho[x] *= sum;
+    }
+    
+    // compute bias and alias
+    self->alias = (long*)malloc(sizeof(long)*self->two_upper_bound_minus_one);
+    self->bias = (dgs_bern_dp_t**)malloc(sizeof(dgs_bern_dp_t*)*self->two_upper_bound_minus_one);
+    
+    // simple robin hood strategy approximates good alias
+    double avg = 1.0 / ((double)self->two_upper_bound_minus_one);
+    long low = _dgs_disc_gauss_dp_min_in_rho(self);
+    long high;
+    while (avg - self->rho[low] > DGS_DISC_GAUSS_STRONG_EQUAL_DIFF) {
+      high = _dgs_disc_gauss_dp_max_in_rho(self);
+      
+      self->bias[low] = dgs_bern_dp_init(self->two_upper_bound_minus_one*self->rho[low]);
+      self->alias[low] = high;
+      self->rho[high] -= (avg - self->rho[low]);
+      self->rho[low] = avg;
+      
+      low = _dgs_disc_gauss_dp_min_in_rho(self);
+    }
+    
     break;
   }
   
@@ -209,7 +276,14 @@ long dgs_disc_gauss_dp_call_uniform_table_offset(dgs_disc_gauss_dp_t *self) {
 }
 
 long dgs_disc_gauss_dp_call_alias(dgs_disc_gauss_dp_t *self) {
-  dgs_die("not implemented");
+  long x = _dgs_randomm_libc(self->two_upper_bound_minus_one);
+  if (self->bias[x]) {
+    if (!dgs_bern_dp_call(self->bias[x])) {
+      x = self->alias[x];
+    }
+  }
+  
+  return x + self->c_z - self->upper_bound_minus_one;
 }
 
 long dgs_disc_gauss_dp_call_uniform_logtable(dgs_disc_gauss_dp_t *self) {
@@ -248,5 +322,15 @@ void dgs_disc_gauss_dp_clear(dgs_disc_gauss_dp_t *self) {
   if (self->B) dgs_bern_uniform_clear(self->B);
   if (self->Bexp) dgs_bern_exp_dp_clear(self->Bexp);
   if (self->rho) free(self->rho);
+  if (self->alias) free(self->alias);
+  if (self->bias) {
+    for(long x=0; x<self->two_upper_bound_minus_one; x++) {
+      if (self->bias[x]) {
+        free(self->bias[x]);
+      }
+    }
+    free(self->bias);
+  }
+  
   free(self);
 }

--- a/dgs/dgs_gauss_mp.c
+++ b/dgs/dgs_gauss_mp.c
@@ -542,7 +542,10 @@ void dgs_disc_gauss_mp_clear(dgs_disc_gauss_mp_t *self) {
   mpz_clear(self->y_z);
   mpz_clear(self->c_z);
   if (self->rho) {
-    for(unsigned long x=0; x<mpz_get_ui(self->upper_bound); x++) {
+    unsigned long range = mpz_get_ui(self->two_upper_bound_minus_one);
+    if (self->call == dgs_disc_gauss_mp_call_uniform_table)
+      range = mpz_get_ui(self->upper_bound);
+    for(unsigned long x=0; x<range; x++) {
       mpfr_clear(self->rho[x]);
     }
     free(self->rho);

--- a/dgs/dgs_gauss_mp.c
+++ b/dgs/dgs_gauss_mp.c
@@ -381,13 +381,13 @@ dgs_disc_gauss_mp_t *dgs_disc_gauss_mp_init(const mpfr_t sigma, const mpfr_t c, 
     }
     
     // compute bias and alias
-    self->alias = (mpz_t*)malloc(sizeof(mpz_t)*range);
+    self->alias = (mpz_t*)calloc(range, sizeof(mpz_t));
     if (!self->alias){
       dgs_disc_gauss_mp_clear(self);
       dgs_die("out of memory");
     }
     
-    self->bias = (dgs_bern_mp_t**)malloc(sizeof(dgs_bern_mp_t*)*range);
+    self->bias = (dgs_bern_mp_t**)calloc(range, sizeof(dgs_bern_mp_t*));
     if (!self->bias){
       dgs_disc_gauss_mp_clear(self);
       dgs_die("out of memory");
@@ -465,10 +465,13 @@ void dgs_disc_gauss_mp_call_alias(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_rand
   unsigned long x = mpz_get_ui(rop);
   if (self->bias[x]) {
     if (!dgs_bern_mp_call(self->bias[x], state)) {
+      if (!self->alias[x]) {
+        free(self);
+        dgs_die("bias initialized but no alias!");
+      }
       mpz_set(rop, self->alias[x]);
     }
   }
-  
   mpz_sub(rop, rop, self->upper_bound_minus_one);
   mpz_add(rop, rop, self->c_z);
 }

--- a/dgs/dgs_gauss_mp.c
+++ b/dgs/dgs_gauss_mp.c
@@ -324,6 +324,14 @@ dgs_disc_gauss_mp_t *dgs_disc_gauss_mp_init(const mpfr_t sigma, const mpfr_t c, 
     break;
   }
 
+  case DGS_DISC_GAUSS_ALIAS: {
+    
+    
+    free(self);
+    dgs_die("not implemented");
+    break;
+  }
+
   default:
     free(self);
     dgs_die("unknown algorithm %d", algorithm);
@@ -358,6 +366,10 @@ void dgs_disc_gauss_mp_call_uniform_table(mpz_t rop, dgs_disc_gauss_mp_t *self, 
   mpz_set_ui(rop, x);
   mpz_sub(rop, rop, self->upper_bound_minus_one);
   mpz_add(rop, rop, self->c_z);
+}
+
+void dgs_disc_gauss_mp_call_alias(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_randstate_t state) {
+  dgs_die("not implemented");
 }
 
 void dgs_disc_gauss_mp_call_uniform_online(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_randstate_t state) {

--- a/tests/test_gauss_z.c
+++ b/tests/test_gauss_z.c
@@ -186,6 +186,7 @@ int main(int argc, char *argv[]) {
   test_mean_dp(10.0, 0.0, 6, DGS_DISC_GAUSS_ALIAS);
   test_mean_dp( 3.3, 1.0, 6, DGS_DISC_GAUSS_ALIAS);
   test_mean_dp( 2.0, 2.0, 6, DGS_DISC_GAUSS_ALIAS);
+  test_mean_dp( 2.0, 1.347, 6, DGS_DISC_GAUSS_ALIAS);
 
   printf("\n");
 

--- a/tests/test_gauss_z.c
+++ b/tests/test_gauss_z.c
@@ -113,18 +113,22 @@ int main(int argc, char *argv[]) {
   test_ratios_dp( 3.0, 6, DGS_DISC_GAUSS_UNIFORM_TABLE);
   test_ratios_dp( 3.0, 6, DGS_DISC_GAUSS_UNIFORM_LOGTABLE);
   test_ratios_dp( 3.0, 6, DGS_DISC_GAUSS_SIGMA2_LOGTABLE);
+  test_ratios_dp( 3.0, 6, DGS_DISC_GAUSS_ALIAS);
   test_ratios_dp( 2.0, 6, DGS_DISC_GAUSS_UNIFORM_ONLINE);
   test_ratios_dp( 2.0, 6, DGS_DISC_GAUSS_UNIFORM_TABLE);
   test_ratios_dp( 2.0, 6, DGS_DISC_GAUSS_UNIFORM_LOGTABLE);
   test_ratios_dp( 2.0, 6, DGS_DISC_GAUSS_SIGMA2_LOGTABLE);
+  test_ratios_dp( 2.0, 6, DGS_DISC_GAUSS_ALIAS);
   test_ratios_dp( 4.0, 3, DGS_DISC_GAUSS_UNIFORM_ONLINE);
   test_ratios_dp( 4.0, 3, DGS_DISC_GAUSS_UNIFORM_TABLE);
   test_ratios_dp( 4.0, 3, DGS_DISC_GAUSS_UNIFORM_LOGTABLE);
   test_ratios_dp( 4.0, 3, DGS_DISC_GAUSS_SIGMA2_LOGTABLE);
+  test_ratios_dp( 4.0, 3, DGS_DISC_GAUSS_ALIAS);
   test_ratios_dp(15.4, 3, DGS_DISC_GAUSS_UNIFORM_ONLINE);
   test_ratios_dp(15.4, 3, DGS_DISC_GAUSS_UNIFORM_TABLE);
   test_ratios_dp(15.4, 3, DGS_DISC_GAUSS_UNIFORM_LOGTABLE);
   test_ratios_dp(15.4, 3, DGS_DISC_GAUSS_SIGMA2_LOGTABLE);
+  test_ratios_dp(15.4, 3, DGS_DISC_GAUSS_ALIAS);
   printf("\n");
 
   printf("# testing [⌊c⌋-⌈στ⌉,…, ⌊c⌋+⌈στ⌉] boundaries #\n");
@@ -144,6 +148,12 @@ int main(int argc, char *argv[]) {
   test_uniform_boundaries_dp(10.0, 0.0, 2, DGS_DISC_GAUSS_UNIFORM_LOGTABLE);
   test_uniform_boundaries_dp( 3.3, 1.0, 1, DGS_DISC_GAUSS_UNIFORM_LOGTABLE);
   test_uniform_boundaries_dp( 2.0, 2.0, 2, DGS_DISC_GAUSS_UNIFORM_LOGTABLE);
+  printf("\n");
+  
+  test_uniform_boundaries_dp( 3.0, 0.0, 2, DGS_DISC_GAUSS_ALIAS);
+  test_uniform_boundaries_dp(10.0, 0.0, 2, DGS_DISC_GAUSS_ALIAS);
+  test_uniform_boundaries_dp( 3.3, 1.0, 1, DGS_DISC_GAUSS_ALIAS);
+  test_uniform_boundaries_dp( 2.0, 2.0, 2, DGS_DISC_GAUSS_ALIAS);
   printf("\n");
 
   printf("# testing c is center #\n");
@@ -169,6 +179,13 @@ int main(int argc, char *argv[]) {
   test_mean_dp(10.0, 0.0, 6, DGS_DISC_GAUSS_SIGMA2_LOGTABLE);
   test_mean_dp( 3.3, 1.0, 6, DGS_DISC_GAUSS_SIGMA2_LOGTABLE);
   test_mean_dp( 2.0, 2.0, 6, DGS_DISC_GAUSS_SIGMA2_LOGTABLE);
+
+  printf("\n");
+  
+  test_mean_dp( 3.0, 0.0, 6, DGS_DISC_GAUSS_ALIAS);
+  test_mean_dp(10.0, 0.0, 6, DGS_DISC_GAUSS_ALIAS);
+  test_mean_dp( 3.3, 1.0, 6, DGS_DISC_GAUSS_ALIAS);
+  test_mean_dp( 2.0, 2.0, 6, DGS_DISC_GAUSS_ALIAS);
 
   printf("\n");
 


### PR DESCRIPTION
This adds support for alias sampling. It is a very simple and very fast sampler. However, memory requirement and setup cost are higher than the alternatives. But for moderate noise parameter (<2000) this is much faster than all the other implemented samplers. Setup cost can be reduced from quadratic (in table size) to quasi linear, but that requires more sophisticated data structures.