### PR TITLE
RRounders including rejection sampling and Karney's algorithm

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,5 @@
-Copyright (c) 2014, Martin Albrecht  <martinralbrecht+dgs@googlemail.com> 
+Copyright (c) 2014, Martin Albrecht  <martinralbrecht+dgs@googlemail.com>
+2018, Michael Walter 
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,9 @@ lib_LTLIBRARIES = libdgs.la
 libdgs_la_SOURCES = dgs/dgs_bern.c \
 	dgs/dgs_gauss_dp.c	\
 	dgs/dgs_gauss_mp.c	\
-	dgs/dgs_rround_dp.c
+	dgs/dgs_rround_dp.c	\
+	dgs/dgs_rround_mp.c	
+	
 
 pkgincludesubdir = $(includedir)/dgs
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,24 +6,29 @@ lib_LTLIBRARIES = libdgs.la
 
 libdgs_la_SOURCES = dgs/dgs_bern.c \
 	dgs/dgs_gauss_dp.c	\
-	dgs/dgs_gauss_mp.c	
+	dgs/dgs_gauss_mp.c	\
+	dgs/dgs_rround_dp.c
 
 pkgincludesubdir = $(includedir)/dgs
 
 pkgincludesub_HEADERS = dgs/dgs_bern.h \
 	dgs/dgs_gauss.h \
 	dgs/dgs.h \
-	dgs/dgs_misc.h
+	dgs/dgs_misc.h \
+	dgs/dgs_rround.h
 
 libdgs_la_LDFLAGS = -release 0.0.$(RELEASE) -no-undefined
 libdgs_la_LIBADD = -lmpfr -lgmp -lm
 
-check_PROGRAMS=test_gauss_z
+check_PROGRAMS=test_gauss_z test_rround_z
 test_gauss_z_SOURCES=tests/test_gauss_z.c
 test_gauss_z_LDFLAGS=-ldgs -lgmp -lmpfr -lm -no-install
 test_gauss_z_CFLAGS=$(AM_CFLAGS)
+test_rround_z_SOURCES=tests/test_rround_z.c
+test_rround_z_LDFLAGS=-ldgs -lgmp -lmpfr -lm -no-install
+test_rround_z_CFLAGS=$(AM_CFLAGS)
 
-TESTS = test_gauss_z
+TESTS = test_gauss_z test_rround_z
 
 # benchmarketing
 

--- a/README.md
+++ b/README.md
@@ -34,37 +34,61 @@ following will suffice:
     make check
 
 ## Algorithms ##
+The library provides two types of algorithms to sample from discrete Gaussians.
+### Samplers
+This type of algorithm is useful to produce a large number of samples
+from the same distribution, i.e. with fixed parameters. The parameters need to be 
+provided during initialization. Available algorithms are:
 
-- `DGS_DISC_GAUSS_UNIFORM_TABLE` - classical rejection sampling, sampling from
-  the uniform distribution and accepted with probability proportional to
-  $\exp(-(x-c)²/(2σ²))$ where $\exp(-(x-c)²/(2σ²))$ is precomputed and stored in
-  a table. Any real-valued `c` is supported.
+  - `DGS_DISC_GAUSS_UNIFORM_TABLE` - classical rejection sampling, sampling from
+    the uniform distribution and accepted with probability proportional to
+    $\exp(-(x-c)²/(2σ²))$ where $\exp(-(x-c)²/(2σ²))$ is precomputed and stored in
+    a table. Any real-valued `c` is supported.
 
-- `DGS_DISC_GAUSS_UNIFORM_LOGTABLE` - samples are drawn from a uniform
-  distribution and accepted with probability proportional to
-  $\exp(-(x-c)²/(2σ²))$ where $\exp(-(x-c)²/(2σ²))$ is computed using
-  logarithmically many calls to Bernoulli distributions. Only integer-valued $c$
-  are supported.
+  - `DGS_DISC_GAUSS_UNIFORM_LOGTABLE` - samples are drawn from a uniform
+    distribution and accepted with probability proportional to
+    $\exp(-(x-c)²/(2σ²))$ where $\exp(-(x-c)²/(2σ²))$ is computed using
+    logarithmically many calls to Bernoulli distributions. Only integer-valued $c$
+    are supported.
 
-- `DGS_DISC_GAUSS_UNIFORM_ONLINE` - samples are drawn from a uniform
-  distribution and accepted with probability proportional to
-  $\exp(-(x-c)²/(2σ²))$ where $\exp(-(x-c)²/(2σ²))$ is computed in each
-  invocation. Typically this is very slow. Any real-valued $c$ is accepted.
+  - `DGS_DISC_GAUSS_UNIFORM_ONLINE` - samples are drawn from a uniform
+    distribution and accepted with probability proportional to
+    $\exp(-(x-c)²/(2σ²))$ where $\exp(-(x-c)²/(2σ²))$ is computed in each
+    invocation. Typically this is very slow. Any real-valued $c$ is accepted.
 
-- `DGS_DISC_SIGMA2_LOGTABLE` - samples are drawn from an easily samplable
-  distribution with $σ = k·σ₂$ where $σ₂ := \sqrt{1/(2\log 2)}$ and accepted
-  with probability proportional to $\exp(-(x-c)²/(2σ²))$ where
-  $\exp(-(x-c)²/(2σ²))$ is computed using logarithmically many calls to
-  Bernoulli distributions (but no calls to $\exp$). Note that this sampler
-  adjusts sigma to match $σ₂·k$ for some integer $k$.  Only integer-valued $c$
-  are supported.
-
-Algorithm 2-4 are described in:
+  - `DGS_DISC_SIGMA2_LOGTABLE` - samples are drawn from an easily samplable
+    distribution with $σ = k·σ₂$ where $σ₂ := \sqrt{1/(2\log 2)}$ and accepted
+    with probability proportional to $\exp(-(x-c)²/(2σ²))$ where
+    $\exp(-(x-c)²/(2σ²))$ is computed using logarithmically many calls to
+    Bernoulli distributions (but no calls to $\exp$). Note that this sampler
+    adjusts sigma to match $σ₂·k$ for some integer $k$.  Only integer-valued $c$
+    are supported.
+    
+  Algorithm 2-4 are described in:
 
   Léo Ducas, Alain Durmus, Tancrède Lepoint and Vadim Lyubashevsky. *Lattice
   Signatures and Bimodal Gaussians*; in Advances in Cryptology – CRYPTO 2013;
   Lecture Notes in Computer Science Volume 8042, 2013, pp 40-56
   [(PDF)](http://www.di.ens.fr/~lyubash/papers/bimodal.pdf)
+
+### Randomized Rounders
+This type of algorithm is useful to produce samples where the parameters of 
+the discrete Gaussian can change for every query, i.e. the center is randomly 
+rounded to a nearby integer. Parameters are provided for every query. 
+Available algorithms are:
+
+  - `DGS_RROUND_UNIFORM_ONLINE` - essentially the same as the sampler 
+  `DGS_DISC_GAUSS_UNIFORM_ONLINE`, where the very little parameter dependent 
+  precomputation (upper bounds on samples, etc) is now done online.
+  
+  - `DGS_RROUND_KARNEY` - Karney's algorithm, similar in spirit to the sampler 
+  `DGS_DISC_SIGMA2_LOGTABLE`, but without the need to precompute log tables and
+  without restriction on the center. 
+  
+  Karney's algorithm is described in:
+  
+  Charles F. F. Karney. *Sampling Exactly from the Normal Distribution*; in
+  ACM Trans. Mathematical Software 42(1), 3:1-14 (Jan. 2016) [(PDF)](https://arxiv.org/pdf/1303.6257)
 
 ## Precisions ##
 
@@ -82,3 +106,7 @@ with ``dgs_gauss_dp.c`` which implements the same algorithms as
     dgs_disc_gauss_dp_t *D = dgs_disc_gauss_dp_init(<sigma>, <c>, <tau>, <algorithm>);
     D->call(D); // as often as needed
     dgs_disc_gauss_dp_clear(D);
+
+    dgs_rround_dp_t *D = dgs_rround_dp_init(<tau>, <algorithm>);
+    D->call(D, <sigma>, <c>); // as often as needed
+    dgs_rround_dp_clear(D);

--- a/benchmarks/Makefile.am
+++ b/benchmarks/Makefile.am
@@ -2,11 +2,15 @@ BENCHCFLAGS = $(AM_CFLAGS)  -I.. @CFLAGS@ -DNDEBUG
 BENCHLIBADD = -lmpfr -lgmp -lm
 BENCHLDFLAGS = -Wl,-rpath,../.libs/ ../.libs/libdgs.la
 
-bin_PROGRAMS = bench_gauss
+bin_PROGRAMS = bench_gauss bench_rround
 
 .PHONY: clean dist-clean
 
 bench_gauss_SOURCES=bench_gauss.c bench.c bench.h
 bench_gauss_CFLAGS=${BENCHCFLAGS}
 bench_gauss_LDFLAGS=${BENCHLDFLAGS} ${BENCHLIBADD}
+
+bench_rround_SOURCES=bench_rround.c bench.c bench.h
+bench_rround_CFLAGS=${BENCHCFLAGS}
+bench_rround_LDFLAGS=${BENCHLDFLAGS} ${BENCHLIBADD}
 

--- a/benchmarks/bench.c
+++ b/benchmarks/bench.c
@@ -57,3 +57,48 @@ void parse_gauss_z_cmdline(cmdline_params_gauss_z_t *params, int argc, char *arg
   if (params->precision != 0 && params->precision != 1)
     dgs_die("precision must be either 0 or 1, but got %d",params->precision);
 }
+
+void print_rround_z_help(const char *name) {
+  //printf("%s:\n\n", name);
+  printf("REQUIRED:\n");
+  printf(" s -- Gaussian width parameter σ, double > 0\n");
+  printf(" t -- cutoff parameter for sampling from uniform distribution,\n");
+  printf("      values outside of [⌊c⌋-⌈στ⌉, ⌊c⌋+⌈στ⌉] are considered to have probability zero.\n");
+  printf("      integer > 0\n");
+  printf(" c -- center of Gaussian distribution. double\n");
+  printf(" a -- algorithm:\n");
+  printf("      %d -- sample from uniform distribution, call exp()\n", DGS_RROUND_UNIFORM_ONLINE);
+  printf(" p -- precision: 0 for double precision, 1 for arbitrary precision\n");
+  printf(" n -- number of trials > 0 (default: 100000)\n");
+}
+
+void parse_rround_z_cmdline(cmdline_params_rround_z_t *params, int argc, char *argv[]) {
+  int c;
+  while ((c = getopt(argc, argv, "s:t:c:a:p:hn:")) != -1)
+    switch (c) {
+    case 's':
+      params->sigma = atof(optarg); break;
+    case 't':
+      params->tau = atol(optarg); break;
+    case 'c':
+      params->c = atof(optarg); break;
+    case 'a':
+      params->algorithm = atoi(optarg); break;
+    case 'p':
+      params->precision = atoi(optarg); break;
+    case 'n':
+      params->ntrials = atoi(optarg); break;
+    case 'h':
+      print_gauss_z_help(argv[0]);
+      exit(0);
+    default:
+      print_gauss_z_help(argv[0]);
+      abort();
+    }
+  if (params->sigma <= 0.0)
+    dgs_die("σ > 0 required, but got σ = %f",params->sigma);
+  if (params->tau <= 0)
+    dgs_die("τ > 0 required, but got τ = %d",params->tau);
+  if (params->precision != 0 && params->precision != 1)
+    dgs_die("precision must be either 0 or 1, but got %d",params->precision);
+}

--- a/benchmarks/bench.c
+++ b/benchmarks/bench.c
@@ -68,6 +68,7 @@ void print_rround_z_help(const char *name) {
   printf(" c -- center of Gaussian distribution. double\n");
   printf(" a -- algorithm:\n");
   printf("      %d -- sample from uniform distribution, call exp()\n", DGS_RROUND_UNIFORM_ONLINE);
+  printf("      %d -- Karney's algorithm\n", DGS_RROUND_KARNEY);
   printf(" p -- precision: 0 for double precision, 1 for arbitrary precision\n");
   printf(" n -- number of trials > 0 (default: 100000)\n");
 }

--- a/benchmarks/bench.h
+++ b/benchmarks/bench.h
@@ -1,6 +1,7 @@
 #include <time.h>
 #include <sys/time.h>
 #include "dgs/dgs_gauss.h"
+#include "dgs/dgs_rround.h"
 
 #define DP 0
 #define MP 1
@@ -19,3 +20,16 @@ typedef struct {
 
 void parse_gauss_z_cmdline(cmdline_params_gauss_z_t *params, int argc, char *argv[]);
 void print_gauss_z_help(const char *name);
+
+typedef struct {
+  double sigma;
+  long tau;
+  double c;
+  dgs_rround_alg_t algorithm;
+  int precision;
+  size_t ntrials;
+} cmdline_params_rround_z_t;
+
+
+void parse_rround_z_cmdline(cmdline_params_rround_z_t *params, int argc, char *argv[]);
+void print_rround_z_help(const char *name);

--- a/benchmarks/bench_rround.c
+++ b/benchmarks/bench_rround.c
@@ -1,0 +1,102 @@
+#include <stdio.h>
+#include <math.h>
+
+#include "dgs.h"
+#include "bench.h"
+
+double run_dp(double sigma, double c, int tau, dgs_rround_alg_t alg, size_t ntrials, unsigned long long *t) {
+  double variance = 0.0;
+  gmp_randstate_t state;
+  gmp_randinit_default(state);
+
+  dgs_rround_dp_t *gen = dgs_rround_dp_init(tau, alg);
+
+  *t =  walltime(0);
+  for(size_t i=0; i<ntrials; i++) {
+    long r = gen->call(gen, sigma, c);
+    variance += ((double)r)*((double)r);
+  }
+  *t = walltime(*t);
+
+  dgs_rround_dp_clear(gen);
+  gmp_randclear(state);
+
+  variance /= ntrials;
+  return sqrt(variance);
+}
+
+double run_mp(double sigma_, double c_, int tau, dgs_rround_alg_t alg, size_t ntrials, unsigned long long *t) {
+  mpfr_set_default_prec(80);
+  mpfr_t sigma;
+  mpfr_init_set_d(sigma, sigma_, MPFR_RNDN);
+  gmp_randstate_t state;
+  gmp_randinit_default(state);
+
+  mpfr_t c;
+  mpfr_init_set_d(c, c_, MPFR_RNDN);
+  dgs_rround_mp_t *gen = dgs_rround_mp_init(tau, alg, mpfr_get_default_prec());
+
+  double variance = 0.0;
+  mpz_t r;
+  mpz_init(r);
+  
+  *t =  walltime(0);
+  for(size_t i=0; i<ntrials; i++) {
+    gen->call(r, gen, sigma, c, state);
+    variance += mpz_get_d(r)*mpz_get_d(r);
+  }
+  *t = walltime(*t);
+  dgs_rround_mp_clear(gen);
+  mpfr_clear(sigma);
+  mpz_clear(r);
+  mpfr_clear(c);
+
+  gmp_randclear(state);
+  
+  variance /= ntrials;
+  return sqrt(variance);
+}
+
+double run(double sigma, double c, int tau, int prec, dgs_rround_alg_t alg, size_t ntrials, unsigned long long *t) {
+  if (prec == MP)
+    return run_mp(sigma, c, tau, alg, ntrials, t);
+  else 
+    return run_dp(sigma, c, tau, alg, ntrials, t);
+}
+
+
+const char *alg_to_str(dgs_disc_gauss_alg_t alg) {
+  switch(alg) {
+  case DGS_RROUND_UNIFORM_ONLINE: return "uniform+online";
+  case DGS_RROUND_KARNEY: return "karney";
+  default: return "unknown";
+  }
+}
+
+int main(int argc, char *argv[]) {
+  
+  unsigned long long t;
+
+  cmdline_params_rround_z_t params;
+  params.sigma = 3.0;
+  params.tau = 6;
+  params.c = 0;
+  params.ntrials = 10000000;
+  params.algorithm = DGS_RROUND_DEFAULT;
+  params.precision = MP;
+
+
+  parse_rround_z_cmdline(&params, argc, argv);
+
+  printf("%s :: σ: %.2f, c: %.2f. τ: %ld, precision: %d, algorithm: %d -- ", argv[0],
+         params.sigma, params.c, params.tau, params.precision, params.algorithm);
+  
+  run(params.sigma, params.c, params.tau, params.precision, params.algorithm, params.ntrials, &t);
+  double walltime = t/100000.0/params.ntrials*(1000.0*1000.0); // μs
+
+  printf("wall time: %8.3f μs per call (rate: %8.3f per second)\n", walltime, 1000.0*1000.0/walltime);
+
+  mpfr_free_cache();
+  
+  return 0;
+}

--- a/dgs/dgs_rround.h
+++ b/dgs/dgs_rround.h
@@ -50,6 +50,7 @@
 typedef enum {
   DGS_RROUND_DEFAULT           = 0x0, //<pick algorithm
   DGS_RROUND_UNIFORM_ONLINE    = 0x1, //<call dgs_disc_gauss_mp_call_uniform_online
+  DGS_RROUND_KARNEY            = 0x2, //<call dgs_disc_gauss_mp_call_karney
 } dgs_rround_alg_t;
 
 struct _dgs_rround_mp_t;
@@ -63,6 +64,9 @@ typedef struct _dgs_rround_dp_t {
   */
 
   size_t tau;
+
+  dgs_bern_uniform_t *B;
+  dgs_bern_dp_t *B_half_exp;
 
   dgs_rround_alg_t algorithm;  //<  which algorithm to use
 
@@ -99,6 +103,14 @@ dgs_rround_dp_t *dgs_rround_dp_init(size_t tau, dgs_rround_alg_t algorithm);
  */
 
 long dgs_rround_dp_call_uniform_online(dgs_rround_dp_t *self, double sigma, double c);
+ 
+  /**
+   Sample from ``dgs_rround_dp_t`` using Karney's algorithm. This is similar
+   to the sigma2 method, but can sample from any c and σ.
+
+   :param self: discrete Gaussian sampler
+ */
+long dgs_rround_dp_call_karney(dgs_rround_dp_t *self, double sigma, double c);
 
 /**
    Free memory.
@@ -106,7 +118,6 @@ long dgs_rround_dp_call_uniform_online(dgs_rround_dp_t *self, double sigma, doub
    :param self: discrete Gaussian rounder
 
  */
-
 void dgs_rround_dp_clear(dgs_rround_dp_t *self);
 
 

--- a/dgs/dgs_rround.h
+++ b/dgs/dgs_rround.h
@@ -103,233 +103,98 @@ long dgs_rround_dp_call_uniform_online(dgs_rround_dp_t *self, double sigma, doub
 void dgs_rround_dp_clear(dgs_rround_dp_t *self);
 
 
-//~ /**
-   //~ Multi-precision Discrete Gaussians `D_{σ,c}`
+/**
+   Multi-precision Discrete Gaussians `D_{σ,c}`
 
-   //~ Return integer `x` with probability
+   Return integer `x` with probability
 
-   //~ `ρ_{σ,c}(x) = exp(-(x-c)²/(2σ²))/exp(-(\ZZ-c)²/(2σ²))`
+   `ρ_{σ,c}(x) = exp(-(x-c)²/(2σ²))/exp(-(\ZZ-c)²/(2σ²))`
 
-   //~ where `exp(-(\ZZ-c)²/(2σ²)) ≈ \sum_{i=-τσ}^{τσ} exp(-(i-c)²/(2σ^²))` is the
-   //~ probability for all of the integers.
+   where `exp(-(\ZZ-c)²/(2σ²)) ≈ \sum_{i=-τσ}^{τσ} exp(-(i-c)²/(2σ^²))` is the
+   probability for all of the integers.
 
-//~ */
+*/
 
-//~ typedef struct _dgs_disc_gauss_mp_t {
+typedef struct _dgs_rround_mp_t {
 
-  //~ /**
-      //~ The width paramter `σ`, i.e. samples are accepted with probability
-      //~ proportional to `\exp(-(x-c)²/(2σ²))`
-   //~ */
+  mpfr_t c_r; //< `c_r := c % 1`
+  mpz_t c_z;  //< c_z := c - (c_r)
 
-  //~ mpfr_t sigma;
+  /**
+     Cutoff `τ`, samples outside the range `(⌊c⌉-⌈στ⌉,...,⌊c⌉+⌈στ⌉)` are
+     considered to have probability zero. This bound applies to algorithms
+     which sample from the uniform distribution.
+  */
 
-  //~ /**
-     //~ The mean of the distribution `c`. The value of `c` does not have to be an
-     //~ integer. However, some algorithms only support integer-valued `c`.
-  //~ */
+  size_t tau;
 
-  //~ mpfr_t c;
+  dgs_rround_alg_t algorithm; //<  which algorithm to use
 
-  //~ mpfr_t c_r; //< `c_r := c % 1`
-  //~ mpz_t c_z;  //< c_z := c - (c_r)
+  /**
+   Return an ``mpz_t`` sampled from this sampler
 
-  //~ /**
-     //~ Cutoff `τ`, samples outside the range `(⌊c⌉-⌈στ⌉,...,⌊c⌉+⌈στ⌉)` are
-     //~ considered to have probability zero. This bound applies to algorithms
-     //~ which sample from the uniform distribution.
-  //~ */
+   :param rop: target value.
+   :param self: discrete Gaussian sampler.
+   :param state: entropy pool.
 
-  //~ size_t tau;
+  */
 
-  //~ dgs_disc_gauss_alg_t algorithm; //<  which algorithm to use
+  void (*call)(mpz_t rop, struct _dgs_rround_mp_t *self, const mpfr_t sigma, const mpfr_t c, gmp_randstate_t state);
 
-  //~ /**
-     //~ We use a uniform Bernoulli to decide signs.
-   //~ */
+  /**
+   We sample ``x`` with ``abs(x) < upper_bound`` in
+   ``DGS_DISC_GAUSS_UNIFORM_ONLINE``, ``DGS_DISC_GAUSS_UNIFORM_TABLE`` and
+   ``DGS_DISC_GAUSS_UNIFORM_LOGTABLE``.
+   */
 
-  //~ dgs_bern_uniform_t *B;
+  mpz_t upper_bound;
 
-  //~ /**
-     //~ To realise rejection sampling, we call `B_{exp(-(x·x)/(2σ²))}` and accept
-     //~ if it returns 1.
+  /**
+   We sample ``x`` with ``abs(x) <= upper_bound - 1`` in
+   ``DGS_DISC_GAUSS_UNIFORM_ONLINE``, ``DGS_DISC_GAUSS_UNIFORM_TABLE`` and
+   ``DGS_DISC_GAUSS_UNIFORM_LOGTABLE``.
+   */
 
-     //~ Used when ``DGS_DISC_GAUSS_UNIFORM_LOGTABLE`` or
-     //~ ``DGS_DISC_GAUSS_SIGMA2_LOGTABLE`` is set.
-   //~ */
+  mpz_t upper_bound_minus_one;
 
-  //~ dgs_bern_exp_mp_t *Bexp;
+  /**
+     There are ``2*upper_bound -1`` elements in the range
+     ``-upper_bound+1,...,upper_bound-1``.
+   */
 
+  mpz_t two_upper_bound_minus_one;
 
-  //~ /**
-     //~ `D_{σ₂,0}` which is easily sampable`
+  /**
+   Precomputed `-1/(2σ²)`.
+  */
 
-     //~ Used when ``DGS_DISC_GAUSS_SIGMA2_LOGTABLE`` is set.
-  //~ */
+  mpfr_t f;
 
-  //~ dgs_disc_gauss_sigma2p_t *D2;
+  mpz_t x; //< space for temporary integer
+  mpfr_t y; // space for temporary rational number
+  mpfr_t z; // space for temporary rational number
 
-  //~ /**
-   //~ Return an ``mpz_t`` sampled from this sampler
+} dgs_rround_mp_t;
 
-   //~ :param rop: target value.
-   //~ :param self: discrete Gaussian sampler.
-   //~ :param state: entropy pool.
+dgs_rround_mp_t *dgs_rround_mp_init(size_t tau, dgs_rround_alg_t algorithm, mpfr_prec_t prec);
 
-  //~ */
+/**
+  Sample from ``dgs_rround_mp_t`` by rejection sampling using the uniform distribution.
 
-  //~ void (*call)(mpz_t rop, struct _dgs_disc_gauss_mp_t *self, gmp_randstate_t state);
+  :param self: discrete Gaussian rounder
 
-  //~ /**
-   //~ We sample ``x`` with ``abs(x) < upper_bound`` in
-   //~ ``DGS_DISC_GAUSS_UNIFORM_ONLINE``, ``DGS_DISC_GAUSS_UNIFORM_TABLE`` and
-   //~ ``DGS_DISC_GAUSS_UNIFORM_LOGTABLE``.
-   //~ */
+ */
 
-  //~ mpz_t upper_bound;
+void dgs_rround_mp_call_uniform_online(mpz_t rop, dgs_rround_mp_t *self, const mpfr_t sigma, const mpfr_t c, gmp_randstate_t state);
 
-  //~ /**
-   //~ We sample ``x`` with ``abs(x) <= upper_bound - 1`` in
-   //~ ``DGS_DISC_GAUSS_UNIFORM_ONLINE``, ``DGS_DISC_GAUSS_UNIFORM_TABLE`` and
-   //~ ``DGS_DISC_GAUSS_UNIFORM_LOGTABLE``.
-   //~ */
 
-  //~ mpz_t upper_bound_minus_one;
+/**
+   Free memory.
 
-  //~ /**
-     //~ There are ``2*upper_bound -1`` elements in the range
-     //~ ``-upper_bound+1,...,upper_bound-1``.
-   //~ */
+   :param self: discrete Gaussian rounder
 
-  //~ mpz_t two_upper_bound_minus_one;
+ */
 
-  //~ /**
-     //~ The multiplier `k` when we sample from `D_{k·σ₂,c}` in
-     //~ ``DGS_DISC_GAUSS_SIGMA2_LOGTABLE``.
-  //~ */
-
-  //~ mpz_t k;
-
-  //~ /**
-   //~ Precomputed `-1/(2σ²)`.
-  //~ */
-
-  //~ mpfr_t f;
-
-  //~ mpz_t x; //< space for temporary integer
-  //~ mpz_t y_z; //< space for temporary integer
-  //~ mpz_t x2; // space for temporary integer
-  //~ mpfr_t y; // space for temporary rational number
-  //~ mpfr_t z; // space for temporary rational number
-
-  //~ /**
-     //~ Precomputed values for `exp(-(x-c)²/(2σ²))` in
-     //~ ``DGS_DISC_GAUSS_UNIFORM_TABLE``
-  //~ */
-
-  //~ mpfr_t *rho;
-  
-    //~ /**
-   //~ * Tables required for alias sampling.
-   //~ */
-   
-  //~ mpz_t* alias;
-  //~ dgs_bern_mp_t** bias;
-
-//~ } dgs_disc_gauss_mp_t;
-
-//~ dgs_disc_gauss_mp_t *dgs_disc_gauss_mp_init(const mpfr_t sigma, const mpfr_t c, size_t tau, dgs_disc_gauss_alg_t algorithm);
-
-//~ /**
-   //~ Sample from ``dgs_disc_gauss_mp_t`` by rejection sampling using the uniform
-   //~ distribution and tabulated ``exp()`` evaluations.
-
-   //~ :param self: discrete Gaussian sampler
-
-   //~ .. note::
-
-      //~ `c` must be an integer in this algorithm
-
- //~ */
-
-//~ void dgs_disc_gauss_mp_call_uniform_table(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_randstate_t state);
-
-//~ /**
-   //~ Sample from ``dgs_disc_gauss_mp_t`` by rejection sampling using the uniform
-   //~ distribution and tabulated ``exp()`` evaluations.
-
-   //~ :param self: discrete Gaussian sampler
-
-   //~ .. note::
-
-      //~ This function makes no assumptions about `c` but requires more resources
-      //~ than ``dgs_disc_gauss_dp_call_uniform_table()``.
-
- //~ */
-
-//~ void dgs_disc_gauss_mp_call_uniform_table_offset(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_randstate_t state);
-
-//~ /**
-   //~ Sample from ``dgs_disc_gauss_mp_t`` by alias sampling. This is extremely fast, 
-   //~ but requires more resources and setup cost is around (2τσ)².
-
-   //~ :param self: discrete Gaussian sampler
- //~ */
-//~ void dgs_disc_gauss_mp_call_alias(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_randstate_t state);
-
-//~ /**
-  //~ Sample from ``dgs_disc_gauss_mp_t`` by rejection sampling using the uniform
-  //~ distribution replacing all ``exp()`` calls with call to Bernoulli distributions.
-
-  //~ :param self: discrete Gaussian sampler
-
-  //~ .. note::
-
-     //~ `c` must be an integer in this algorithm
- //~ */
-
-//~ void dgs_disc_gauss_mp_call_uniform_logtable(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_randstate_t state);
-
-//~ /**
-  //~ Sample from ``dgs_disc_gauss_mp_t`` by rejection sampling using the uniform distribution.
-
-  //~ :param self: discrete Gaussian sampler
-
- //~ */
-
-//~ void dgs_disc_gauss_mp_call_uniform_online(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_randstate_t state);
-
-//~ /**
-  //~ Sample from ``dgs_disc_gauss_mp_t`` by rejection sampling using the `D_{k·σ₂,0}`
-  //~ distribution replacing all ``exp()`` calls with call to Bernoulli distributions.
-
-  //~ :param self: Discrete Gaussian sampler
-
-  //~ .. note::
-
-     //~ `c` must be an integer in this algorithm.
- //~ */
-
-//~ void dgs_disc_gauss_mp_call_sigma2_logtable(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_randstate_t state);
-
-//~ /**
-   //~ Clear cache of random bits.
-
-   //~ :param self: discrete Gaussian sampler
-
- //~ */
-
-//~ static inline void dgs_disc_gauss_mp_flush_cache(dgs_disc_gauss_mp_t *self) {
-  //~ self->B->count = self->B->length;
-//~ }
-
-//~ /**
-   //~ Free memory.
-
-   //~ :param self: discrete Gaussian sadpler
-
- //~ */
-
-//~ void dgs_disc_gauss_mp_clear(dgs_disc_gauss_mp_t *self);
+void dgs_rround_mp_clear(dgs_rround_mp_t *self);
 
 #endif //DGS_RROUND__H

--- a/dgs/dgs_rround.h
+++ b/dgs/dgs_rround.h
@@ -1,0 +1,335 @@
+/**
+   Generic Discrete Gaussian Rounding over the Integers.
+
+   A discrete Gaussian distribution on the Integers is a distribution where the
+   integer `x` is sampled with probability proportional to `exp(-(x-c)²/(2σ²))`.
+   It is denoted by `D_{σ,c}` where `σ` is the width parameter (close to the
+   standard deviation) and `c` is the center.
+
+   AVAILABLE ALGORITHMS:
+
+ - ``DGS_DISC_GAUSS_UNIFORM_ONLINE`` - samples are drawn from a uniform
+   distribution and accepted with probability proportional to
+   `\exp(-(x-c)²/(2σ²))` where `\exp(-(x-c)²/(2σ²))` is computed in each
+   invocation. Typically this is very slow. Any real-valued `c` is accepted.
+
+  AVAILABLE PRECISIONS:
+
+  - ``mp`` - multi-precision using MPFR, cf. ``dgs_gauss_mp.c``
+
+  - ``dp`` - double precision using machine doubles, cf. ``dgs_gauss_dp.c``.
+
+  For readers unfamiliar with the implemented algorithms it makes sense to start
+  with ``dgs_gauss_dp.c`` which implements the same algorithms as
+  ``dgs_gauss_mp.c`` should be easier to read.
+
+  TYPICAL USAGE::
+
+      dgs_disc_gauss_dp_t *D = dgs_disc_gauss_dp_init(<sigma>, <c>, <tau>, <algorithm>);
+      D->call(D); // as often as needed
+      dgs_disc_gauss_dp_clear(D);
+
+   .. author:: Michael Walter
+
+*/
+
+#ifndef DGS_RROUND__H
+#define DGS_RROUND__H
+
+#include "dgs_gauss.h"
+
+/**
+   Available Algorithms
+*/
+
+typedef enum {
+  DGS_RROUND_DEFAULT           = 0x0, //<pick algorithm
+  DGS_RROUND_UNIFORM_ONLINE    = 0x1, //<call dgs_disc_gauss_mp_call_uniform_online
+} dgs_rround_alg_t;
+
+struct _dgs_rround_mp_t;
+
+typedef struct _dgs_rround_dp_t {
+
+  /**
+     Cutoff `τ`, samples outside the range `(⌊c⌉-⌈στ⌉,...,⌊c⌉+⌈στ⌉)` are
+     considered to have probability zero. This bound applies to algorithms
+     which sample from the uniform distribution.
+  */
+
+  size_t tau;
+
+  dgs_rround_alg_t algorithm;  //<  which algorithm to use
+
+  /**
+   Return an ``long`` sampled from this sampler
+
+   :param self: discrete Gaussian sampler.
+   :param sigma: noise parameter.
+   :param c: center.
+
+  */
+
+  long (*call)(struct _dgs_rround_dp_t *self, double sigma, double c);
+
+} dgs_rround_dp_t;
+
+/**
+ Create a new double-precision discrete Gaussian rounder.
+
+ :param tau: cutoff `τ`
+ :param algorithm: algorithm to use.
+
+*/
+
+dgs_rround_dp_t *dgs_rround_dp_init(size_t tau, dgs_rround_alg_t algorithm);
+
+/**
+   Sample from ``dgs_rround_dp_t`` by rejection sampling using the uniform distribution
+
+   :param self: Discrete Gaussian rounder
+
+ */
+
+long dgs_rround_dp_call_uniform_online(dgs_rround_dp_t *self, double sigma, double c);
+
+/**
+   Free memory.
+
+   :param self: discrete Gaussian rounder
+
+ */
+
+void dgs_rround_dp_clear(dgs_rround_dp_t *self);
+
+
+//~ /**
+   //~ Multi-precision Discrete Gaussians `D_{σ,c}`
+
+   //~ Return integer `x` with probability
+
+   //~ `ρ_{σ,c}(x) = exp(-(x-c)²/(2σ²))/exp(-(\ZZ-c)²/(2σ²))`
+
+   //~ where `exp(-(\ZZ-c)²/(2σ²)) ≈ \sum_{i=-τσ}^{τσ} exp(-(i-c)²/(2σ^²))` is the
+   //~ probability for all of the integers.
+
+//~ */
+
+//~ typedef struct _dgs_disc_gauss_mp_t {
+
+  //~ /**
+      //~ The width paramter `σ`, i.e. samples are accepted with probability
+      //~ proportional to `\exp(-(x-c)²/(2σ²))`
+   //~ */
+
+  //~ mpfr_t sigma;
+
+  //~ /**
+     //~ The mean of the distribution `c`. The value of `c` does not have to be an
+     //~ integer. However, some algorithms only support integer-valued `c`.
+  //~ */
+
+  //~ mpfr_t c;
+
+  //~ mpfr_t c_r; //< `c_r := c % 1`
+  //~ mpz_t c_z;  //< c_z := c - (c_r)
+
+  //~ /**
+     //~ Cutoff `τ`, samples outside the range `(⌊c⌉-⌈στ⌉,...,⌊c⌉+⌈στ⌉)` are
+     //~ considered to have probability zero. This bound applies to algorithms
+     //~ which sample from the uniform distribution.
+  //~ */
+
+  //~ size_t tau;
+
+  //~ dgs_disc_gauss_alg_t algorithm; //<  which algorithm to use
+
+  //~ /**
+     //~ We use a uniform Bernoulli to decide signs.
+   //~ */
+
+  //~ dgs_bern_uniform_t *B;
+
+  //~ /**
+     //~ To realise rejection sampling, we call `B_{exp(-(x·x)/(2σ²))}` and accept
+     //~ if it returns 1.
+
+     //~ Used when ``DGS_DISC_GAUSS_UNIFORM_LOGTABLE`` or
+     //~ ``DGS_DISC_GAUSS_SIGMA2_LOGTABLE`` is set.
+   //~ */
+
+  //~ dgs_bern_exp_mp_t *Bexp;
+
+
+  //~ /**
+     //~ `D_{σ₂,0}` which is easily sampable`
+
+     //~ Used when ``DGS_DISC_GAUSS_SIGMA2_LOGTABLE`` is set.
+  //~ */
+
+  //~ dgs_disc_gauss_sigma2p_t *D2;
+
+  //~ /**
+   //~ Return an ``mpz_t`` sampled from this sampler
+
+   //~ :param rop: target value.
+   //~ :param self: discrete Gaussian sampler.
+   //~ :param state: entropy pool.
+
+  //~ */
+
+  //~ void (*call)(mpz_t rop, struct _dgs_disc_gauss_mp_t *self, gmp_randstate_t state);
+
+  //~ /**
+   //~ We sample ``x`` with ``abs(x) < upper_bound`` in
+   //~ ``DGS_DISC_GAUSS_UNIFORM_ONLINE``, ``DGS_DISC_GAUSS_UNIFORM_TABLE`` and
+   //~ ``DGS_DISC_GAUSS_UNIFORM_LOGTABLE``.
+   //~ */
+
+  //~ mpz_t upper_bound;
+
+  //~ /**
+   //~ We sample ``x`` with ``abs(x) <= upper_bound - 1`` in
+   //~ ``DGS_DISC_GAUSS_UNIFORM_ONLINE``, ``DGS_DISC_GAUSS_UNIFORM_TABLE`` and
+   //~ ``DGS_DISC_GAUSS_UNIFORM_LOGTABLE``.
+   //~ */
+
+  //~ mpz_t upper_bound_minus_one;
+
+  //~ /**
+     //~ There are ``2*upper_bound -1`` elements in the range
+     //~ ``-upper_bound+1,...,upper_bound-1``.
+   //~ */
+
+  //~ mpz_t two_upper_bound_minus_one;
+
+  //~ /**
+     //~ The multiplier `k` when we sample from `D_{k·σ₂,c}` in
+     //~ ``DGS_DISC_GAUSS_SIGMA2_LOGTABLE``.
+  //~ */
+
+  //~ mpz_t k;
+
+  //~ /**
+   //~ Precomputed `-1/(2σ²)`.
+  //~ */
+
+  //~ mpfr_t f;
+
+  //~ mpz_t x; //< space for temporary integer
+  //~ mpz_t y_z; //< space for temporary integer
+  //~ mpz_t x2; // space for temporary integer
+  //~ mpfr_t y; // space for temporary rational number
+  //~ mpfr_t z; // space for temporary rational number
+
+  //~ /**
+     //~ Precomputed values for `exp(-(x-c)²/(2σ²))` in
+     //~ ``DGS_DISC_GAUSS_UNIFORM_TABLE``
+  //~ */
+
+  //~ mpfr_t *rho;
+  
+    //~ /**
+   //~ * Tables required for alias sampling.
+   //~ */
+   
+  //~ mpz_t* alias;
+  //~ dgs_bern_mp_t** bias;
+
+//~ } dgs_disc_gauss_mp_t;
+
+//~ dgs_disc_gauss_mp_t *dgs_disc_gauss_mp_init(const mpfr_t sigma, const mpfr_t c, size_t tau, dgs_disc_gauss_alg_t algorithm);
+
+//~ /**
+   //~ Sample from ``dgs_disc_gauss_mp_t`` by rejection sampling using the uniform
+   //~ distribution and tabulated ``exp()`` evaluations.
+
+   //~ :param self: discrete Gaussian sampler
+
+   //~ .. note::
+
+      //~ `c` must be an integer in this algorithm
+
+ //~ */
+
+//~ void dgs_disc_gauss_mp_call_uniform_table(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_randstate_t state);
+
+//~ /**
+   //~ Sample from ``dgs_disc_gauss_mp_t`` by rejection sampling using the uniform
+   //~ distribution and tabulated ``exp()`` evaluations.
+
+   //~ :param self: discrete Gaussian sampler
+
+   //~ .. note::
+
+      //~ This function makes no assumptions about `c` but requires more resources
+      //~ than ``dgs_disc_gauss_dp_call_uniform_table()``.
+
+ //~ */
+
+//~ void dgs_disc_gauss_mp_call_uniform_table_offset(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_randstate_t state);
+
+//~ /**
+   //~ Sample from ``dgs_disc_gauss_mp_t`` by alias sampling. This is extremely fast, 
+   //~ but requires more resources and setup cost is around (2τσ)².
+
+   //~ :param self: discrete Gaussian sampler
+ //~ */
+//~ void dgs_disc_gauss_mp_call_alias(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_randstate_t state);
+
+//~ /**
+  //~ Sample from ``dgs_disc_gauss_mp_t`` by rejection sampling using the uniform
+  //~ distribution replacing all ``exp()`` calls with call to Bernoulli distributions.
+
+  //~ :param self: discrete Gaussian sampler
+
+  //~ .. note::
+
+     //~ `c` must be an integer in this algorithm
+ //~ */
+
+//~ void dgs_disc_gauss_mp_call_uniform_logtable(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_randstate_t state);
+
+//~ /**
+  //~ Sample from ``dgs_disc_gauss_mp_t`` by rejection sampling using the uniform distribution.
+
+  //~ :param self: discrete Gaussian sampler
+
+ //~ */
+
+//~ void dgs_disc_gauss_mp_call_uniform_online(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_randstate_t state);
+
+//~ /**
+  //~ Sample from ``dgs_disc_gauss_mp_t`` by rejection sampling using the `D_{k·σ₂,0}`
+  //~ distribution replacing all ``exp()`` calls with call to Bernoulli distributions.
+
+  //~ :param self: Discrete Gaussian sampler
+
+  //~ .. note::
+
+     //~ `c` must be an integer in this algorithm.
+ //~ */
+
+//~ void dgs_disc_gauss_mp_call_sigma2_logtable(mpz_t rop, dgs_disc_gauss_mp_t *self, gmp_randstate_t state);
+
+//~ /**
+   //~ Clear cache of random bits.
+
+   //~ :param self: discrete Gaussian sampler
+
+ //~ */
+
+//~ static inline void dgs_disc_gauss_mp_flush_cache(dgs_disc_gauss_mp_t *self) {
+  //~ self->B->count = self->B->length;
+//~ }
+
+//~ /**
+   //~ Free memory.
+
+   //~ :param self: discrete Gaussian sadpler
+
+ //~ */
+
+//~ void dgs_disc_gauss_mp_clear(dgs_disc_gauss_mp_t *self);
+
+#endif //DGS_RROUND__H

--- a/dgs/dgs_rround.h
+++ b/dgs/dgs_rround.h
@@ -181,7 +181,7 @@ typedef struct _dgs_rround_mp_t {
   mpz_t x; //< space for temporary integer
   mpfr_t y; // space for temporary rational number
   mpfr_t z; // space for temporary rational number
-
+  mpfr_t tmp;
 } dgs_rround_mp_t;
 
 dgs_rround_mp_t *dgs_rround_mp_init(size_t tau, dgs_rround_alg_t algorithm, mpfr_prec_t prec);

--- a/dgs/dgs_rround_dp.c
+++ b/dgs/dgs_rround_dp.c
@@ -1,25 +1,19 @@
-/**
- * \file dgs.h
- *
- * \author Martin Albrecht <martinralbrecht+dgs@googlemail.com>
- */
-
 /******************************************************************************
 *
-*                        DGS - Discrete Gaussian Samplers
+*                        DGS - Discrete Gaussian Rounders
 *
-* Copyright (c) 2014, Martin Albrecht  <martinralbrecht+dgs@googlemail.com> 
+* Copyright (c) 2014, Martin Albrecht  <martinralbrecht+dgs@googlemail.com>
 * All rights reserved.
-* 
+*
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are met:
-* 
+*
 * 1. Redistributions of source code must retain the above copyright notice, this
-*    list of conditions and the following disclaimer. 
+*    list of conditions and the following disclaimer.
 * 2. Redistributions in binary form must reproduce the above copyright notice,
 *    this list of conditions and the following disclaimer in the documentation
 *    and/or other materials provided with the distribution.
-* 
+*
 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -30,18 +24,69 @@
 * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-* 
+*
 * The views and conclusions contained in the software and documentation are
 * those of the authors and should not be interpreted as representing official
 * policies, either expressed or implied, of the FreeBSD Project.
 ******************************************************************************/
 
-#ifndef DGS__H
-#define DGS__H
+#include "dgs.h"
+#include <assert.h>
+#include <stdlib.h>
+#include <math.h>
 
-#include "dgs_misc.h"
-#include "dgs_bern.h"
-#include "dgs_gauss.h"
-#include "dgs_rround.h"
 
-#endif //DGS__H
+dgs_rround_dp_t *dgs_rround_dp_init(size_t tau, dgs_rround_alg_t algorithm) {
+  if (tau == 0)
+    dgs_die("tau must be > 0");
+
+  dgs_rround_dp_t *self = (dgs_rround_dp_t*)calloc(sizeof(dgs_rround_dp_t),1);
+  if (!self) dgs_die("out of memory");
+
+  self->tau = tau;
+
+  if (algorithm == DGS_RROUND_DEFAULT) {
+    algorithm = DGS_RROUND_UNIFORM_ONLINE;
+  }
+  self->algorithm = algorithm;
+
+  switch(algorithm) {
+
+  case DGS_DISC_GAUSS_UNIFORM_ONLINE:
+    self->call = dgs_rround_dp_call_uniform_online;
+
+    break;
+  
+  default:
+    dgs_rround_dp_clear(self);
+    dgs_die("unknown algorithm %d", algorithm);
+  }
+  return self;
+}
+
+long dgs_rround_dp_call_uniform_online(dgs_rround_dp_t *self, double sigma, double c) {
+  if (sigma <= 0.0)
+    dgs_die("sigma must be > 0");
+  
+  size_t upper_bound = ceil(sigma*self->tau) + 1;
+  size_t upper_bound_minus_one = upper_bound - 1;
+  size_t two_upper_bound_minus_one = 2*upper_bound - 1;
+  double f = -1.0/(2.0*(sigma*sigma));
+  
+  long x;
+  double y, z;
+  do {
+    x = ((long)c) + _dgs_randomm_libc(two_upper_bound_minus_one) - upper_bound_minus_one;
+    z = exp(((double)x-c)*((double)x-c)*f);
+    y = drand48();
+  } while (y >= z);
+
+  return x;
+}
+
+
+void dgs_rround_dp_clear(dgs_rround_dp_t *self) {
+  assert(self != NULL);
+  
+  free(self);
+}

--- a/dgs/dgs_rround_dp.c
+++ b/dgs/dgs_rround_dp.c
@@ -1,8 +1,8 @@
 /******************************************************************************
 *
-*                        DGS - Discrete Gaussian Rounders
+*                        DGR - Discrete Gaussian Rounders
 *
-* Copyright (c) 2014, Martin Albrecht  <martinralbrecht+dgs@googlemail.com>
+* Copyright (c) 2014, Michael Walter.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/dgs/dgs_rround_dp.c
+++ b/dgs/dgs_rround_dp.c
@@ -2,7 +2,7 @@
 *
 *                        DGR - Discrete Gaussian Rounders
 *
-* Copyright (c) 2014, Michael Walter.
+* Copyright (c) 2018, Michael Walter
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
@@ -69,7 +69,7 @@ dgs_rround_dp_t *dgs_rround_dp_init(size_t tau, dgs_rround_alg_t algorithm) {
   self->tau = tau;
 
   if (algorithm == DGS_RROUND_DEFAULT) {
-    algorithm = DGS_RROUND_UNIFORM_ONLINE;
+    algorithm = DGS_RROUND_KARNEY;
   }
   self->algorithm = algorithm;
 

--- a/dgs/dgs_rround_mp.c
+++ b/dgs/dgs_rround_mp.c
@@ -47,16 +47,13 @@ static inline void _dgs_rround_mp_init_f(mpfr_t f, const mpfr_t sigma) {
 static inline void _dgs_rround_mp_init_upper_bound(mpz_t upper_bound,
                                                        mpz_t upper_bound_minus_one,
                                                        mpz_t two_upper_bound_minus_one,
-                                                       const mpfr_t sigma, size_t tailcut) {
-  mpfr_t tmp;
-  mpfr_init2(tmp, mpfr_get_prec(sigma));
+                                                       const mpfr_t sigma, size_t tailcut, mpfr_t tmp) {
   mpfr_mul_ui(tmp, sigma, tailcut, MPFR_RNDN); // tmp = σ·τ
   mpfr_add_ui(tmp, tmp, 1, MPFR_RNDN); // tmp = σ·τ + 1
   mpfr_get_z(upper_bound, tmp, MPFR_RNDU); // upper_bound = ⌈σ·τ + 1⌉
   mpz_sub_ui(upper_bound_minus_one, upper_bound, 1); // upper_bound - 1 = ⌈σ·τ⌉
   mpz_mul_ui(two_upper_bound_minus_one, upper_bound, 2);
   mpz_sub_ui(two_upper_bound_minus_one, two_upper_bound_minus_one, 1); // 2·upper_bound - 1
-  mpfr_clear(tmp);
 }
 
 dgs_rround_mp_t *dgs_rround_mp_init(size_t tau, dgs_rround_alg_t algorithm, mpfr_prec_t prec) {
@@ -72,7 +69,9 @@ dgs_rround_mp_t *dgs_rround_mp_init(size_t tau, dgs_rround_alg_t algorithm, mpfr
 
   mpz_init(self->c_z);
   mpfr_init2(self->c_r, prec);
-
+  
+  mpfr_init2(self->tmp, prec);
+  
   self->tau = tau;
 
   if (algorithm == DGS_RROUND_DEFAULT) {
@@ -108,7 +107,7 @@ void dgs_rround_mp_call_uniform_online(mpz_t rop, dgs_rround_mp_t *self, const m
   _dgs_rround_mp_init_upper_bound(self->upper_bound,
                                         self->upper_bound_minus_one,
                                         self->two_upper_bound_minus_one,
-                                        sigma, self->tau);
+                                        sigma, self->tau, self->tmp);
   _dgs_rround_mp_init_f(self->f, sigma);
   
   do {
@@ -133,6 +132,7 @@ void dgs_rround_mp_clear(dgs_rround_mp_t *self) {
   mpfr_clear(self->z);
   mpfr_clear(self->c_r);
   mpz_clear(self->c_z);
+  mpfr_clear(self->tmp);
   
   if (self->upper_bound)
     mpz_clear(self->upper_bound);

--- a/dgs/dgs_rround_mp.c
+++ b/dgs/dgs_rround_mp.c
@@ -1,0 +1,152 @@
+/******************************************************************************
+*
+*                        DGS - Discrete Gaussian Samplers
+*
+* Copyright (c) 2014, Martin Albrecht  <martinralbrecht+dgs@googlemail.com>
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The views and conclusions contained in the software and documentation are
+* those of the authors and should not be interpreted as representing official
+* policies, either expressed or implied, of the FreeBSD Project.
+******************************************************************************/
+
+#include "dgs.h"
+#include <assert.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <math.h>
+
+/** GENERAL SIGMA :: INIT **/
+
+static inline void _dgs_rround_mp_init_f(mpfr_t f, const mpfr_t sigma) {
+  mpfr_set(f, sigma, MPFR_RNDN);
+  mpfr_sqr(f, f, MPFR_RNDN); // f = σ²
+  mpfr_mul_ui(f, f, 2, MPFR_RNDN); // f = 2 σ²
+  mpfr_ui_div(f, 1, f, MPFR_RNDN);  // f = 1/(2 σ²)
+  mpfr_neg(f, f, MPFR_RNDN); // f = -1/(2 σ²)
+}
+
+static inline void _dgs_rround_mp_init_upper_bound(mpz_t upper_bound,
+                                                       mpz_t upper_bound_minus_one,
+                                                       mpz_t two_upper_bound_minus_one,
+                                                       const mpfr_t sigma, size_t tailcut) {
+  mpfr_t tmp;
+  mpfr_init2(tmp, mpfr_get_prec(sigma));
+  mpfr_mul_ui(tmp, sigma, tailcut, MPFR_RNDN); // tmp = σ·τ
+  mpfr_add_ui(tmp, tmp, 1, MPFR_RNDN); // tmp = σ·τ + 1
+  mpfr_get_z(upper_bound, tmp, MPFR_RNDU); // upper_bound = ⌈σ·τ + 1⌉
+  mpz_sub_ui(upper_bound_minus_one, upper_bound, 1); // upper_bound - 1 = ⌈σ·τ⌉
+  mpz_mul_ui(two_upper_bound_minus_one, upper_bound, 2);
+  mpz_sub_ui(two_upper_bound_minus_one, two_upper_bound_minus_one, 1); // 2·upper_bound - 1
+  mpfr_clear(tmp);
+}
+
+dgs_rround_mp_t *dgs_rround_mp_init(size_t tau, dgs_rround_alg_t algorithm, mpfr_prec_t prec) {
+  if (tau == 0)
+    dgs_die("tau must be > 0");
+
+  dgs_rround_mp_t *self = (dgs_rround_mp_t*)calloc(sizeof(dgs_rround_mp_t),1);
+  if (!self) dgs_die("out of memory");
+
+  mpz_init(self->x);
+  mpfr_init2(self->y, prec);
+  mpfr_init2(self->z, prec);
+
+  mpz_init(self->c_z);
+  mpfr_init2(self->c_r, prec);
+
+  self->tau = tau;
+
+  if (algorithm == DGS_RROUND_DEFAULT) {
+    algorithm = DGS_RROUND_UNIFORM_ONLINE;
+  }
+  self->algorithm = algorithm;
+
+  switch(algorithm) {
+
+  case DGS_RROUND_UNIFORM_ONLINE: {
+    self->call = dgs_rround_mp_call_uniform_online;
+    mpfr_init2(self->f, prec);
+    mpz_init(self->upper_bound);
+    mpz_init(self->upper_bound_minus_one);
+    mpz_init(self->two_upper_bound_minus_one);
+   break;
+  }
+
+  default:
+    free(self);
+    dgs_die("unknown algorithm %d", algorithm);
+  }
+  return self;
+}
+
+/** GENERAL SIGMA :: CALL **/
+
+void dgs_rround_mp_call_uniform_online(mpz_t rop, dgs_rround_mp_t *self, const mpfr_t sigma, const mpfr_t c, gmp_randstate_t state) {
+  if (mpfr_cmp_ui(sigma,0)<= 0)
+    dgs_die("sigma must be > 0");
+  
+  mpfr_get_z(self->c_z, c, MPFR_RNDN);
+  mpfr_sub_z(self->c_r, c, self->c_z, MPFR_RNDN);
+  
+  _dgs_rround_mp_init_upper_bound(self->upper_bound,
+                                        self->upper_bound_minus_one,
+                                        self->two_upper_bound_minus_one,
+                                        sigma, self->tau);
+  _dgs_rround_mp_init_f(self->f, sigma);
+  
+  do {
+    mpz_urandomm(self->x, state, self->two_upper_bound_minus_one);
+    mpz_sub(self->x, self->x, self->upper_bound_minus_one);
+    mpfr_set_z(self->z, self->x, MPFR_RNDN);
+    mpfr_sub(self->z, self->z, self->c_r, MPFR_RNDN);
+    mpfr_mul(self->z, self->z, self->z, MPFR_RNDN);
+    mpfr_mul(self->z, self->z, self->f, MPFR_RNDN);
+    mpfr_exp(self->z, self->z, MPFR_RNDN);
+    mpfr_urandomb(self->y, state);
+  } while (mpfr_cmp(self->y, self->z) >= 0);
+
+  mpz_set(rop, self->x);
+  mpz_add(rop, rop, self->c_z);
+}
+
+
+/** GENERAL SIGMA :: CLEAR **/
+
+void dgs_rround_mp_clear(dgs_rround_mp_t *self) {
+  mpz_clear(self->x);
+  mpfr_clear(self->y);
+  mpfr_clear(self->f);
+  mpfr_clear(self->z);
+  mpfr_clear(self->c_r);
+  mpz_clear(self->c_z);
+  
+  if (self->upper_bound)
+    mpz_clear(self->upper_bound);
+  if (self->upper_bound_minus_one)
+    mpz_clear(self->upper_bound_minus_one);
+  if (self->two_upper_bound_minus_one)
+    mpz_clear(self->two_upper_bound_minus_one);
+
+  free(self);
+}

--- a/dgs/dgs_rround_mp.c
+++ b/dgs/dgs_rround_mp.c
@@ -1,8 +1,8 @@
 /******************************************************************************
 *
-*                        DGS - Discrete Gaussian Samplers
+*                        DGR - Discrete Gaussian Rounders
 *
-* Copyright (c) 2014, Martin Albrecht  <martinralbrecht+dgs@googlemail.com>
+* Copyright (c) 2014, Michael Walter
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
@@ -35,8 +35,6 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <math.h>
-
-/** GENERAL SIGMA :: INIT **/
 
 static inline void _dgs_rround_mp_init_f(mpfr_t f, const mpfr_t sigma) {
   mpfr_set(f, sigma, MPFR_RNDN);
@@ -100,8 +98,6 @@ dgs_rround_mp_t *dgs_rround_mp_init(size_t tau, dgs_rround_alg_t algorithm, mpfr
   return self;
 }
 
-/** GENERAL SIGMA :: CALL **/
-
 void dgs_rround_mp_call_uniform_online(mpz_t rop, dgs_rround_mp_t *self, const mpfr_t sigma, const mpfr_t c, gmp_randstate_t state) {
   if (mpfr_cmp_ui(sigma,0)<= 0)
     dgs_die("sigma must be > 0");
@@ -129,9 +125,6 @@ void dgs_rround_mp_call_uniform_online(mpz_t rop, dgs_rround_mp_t *self, const m
   mpz_set(rop, self->x);
   mpz_add(rop, rop, self->c_z);
 }
-
-
-/** GENERAL SIGMA :: CLEAR **/
 
 void dgs_rround_mp_clear(dgs_rround_mp_t *self) {
   mpz_clear(self->x);

--- a/tests/test_rround_z.c
+++ b/tests/test_rround_z.c
@@ -1,0 +1,127 @@
+#include <math.h>
+#include "dgs/dgs_rround.h"
+
+#define NTRIALS 1<<18
+#define TOLERANCE 0.1
+#define BOUND 2
+
+int test_defaults_dp() {
+  dgs_rround_dp_t *self;
+  self = dgs_rround_dp_init(6, DGS_RROUND_DEFAULT);
+  if (self->algorithm != DGS_RROUND_KARNEY)
+    dgs_die("automatic choice of Karney's algorithm failed (%d)", self->algorithm);
+  dgs_rround_dp_clear(self);
+
+  printf("passed\n");
+  return 0;
+}
+
+int test_uniform_boundaries_dp(double sigma, double c, size_t tau, dgs_rround_alg_t algorithm) {
+  dgs_rround_dp_t *self = dgs_rround_dp_init(tau, algorithm);
+
+    printf("σ: %6.2f, c: %6.2f. τ: %2ld, precision: double, algorithm: %d\n", sigma, c, self->tau, self->algorithm);
+
+
+  long lower_bound = ((long)c) - ceil(sigma * self->tau);
+  long upper_bound = ((long)c) + ceil(sigma * self->tau);
+
+  for(size_t i=0; i<NTRIALS; i++) {
+    long r = self->call(self, sigma, c);
+    if(__DGS_UNLIKELY(r < lower_bound))
+      dgs_die("r (%ld) < lower_bound (%ld)", r, lower_bound);
+    else if(__DGS_UNLIKELY(r > upper_bound))
+      dgs_die("r (%ld) > upper_bound (%ld)", r, upper_bound);
+  }
+  return 0;
+}
+
+/**
+ We test if the proportional probabilities holds
+*/
+#define RHO(x) exp(-(x*x)/(2*sigma*sigma))
+
+int test_ratios_dp(double sigma, size_t tau, dgs_rround_alg_t algorithm) {
+  printf("σ: %6.2f, c:    0.0. τ: %2ld, precision: double, algorithm: %d\n", sigma, tau, algorithm);
+
+  dgs_rround_dp_t *self = dgs_rround_dp_init(tau, algorithm);
+
+  double ctr[2*BOUND+1];
+
+  for(size_t i=0; i<NTRIALS; i++) {
+    long r = self->call(self, sigma, 0);
+    if (abs(r) <= BOUND)
+      ctr[r+BOUND] += 1;
+  }
+
+  for(long i=-BOUND; i<=BOUND; i++) {
+    double left  = ctr[BOUND+1]/ctr[BOUND+i];
+    double right = RHO(0)/RHO(i);
+    if (fabs(log(left/right)) >= 0.4)
+      dgs_die("exp(-((-c)²)/(2σ²))/exp(-((%d-c)²)/(2σ²)) = %7.5f != %7.5f (%7.5f)", i, right, left, fabs(log(left/right)));
+  }
+  return 0;
+}
+
+int test_mean_dp(double sigma, double c, size_t tau, dgs_rround_alg_t algorithm) {
+
+  printf("σ: %6.2f, c: %6.2f. τ: %2ld, precision: double, algorithm: %d\n",sigma, c, tau, algorithm);
+
+  dgs_rround_dp_t *self = dgs_rround_dp_init(tau, algorithm);
+
+  double mean = 0.0;
+
+  for(size_t i=0; i<NTRIALS; i++) {
+    long r = self->call(self, sigma, c);
+    mean += r;
+
+  }
+
+  mean /=NTRIALS;
+
+  if(fabs(mean - c) > TOLERANCE)
+    dgs_die("expected mean %6.2f but got %6.2f",c, mean);
+
+  return 0;
+}
+
+
+int main(int argc, char *argv[]) {
+  printf("# testing defaults #\n");
+  test_defaults_dp();
+  printf("\n");
+
+  printf("# testing proportional probabilities #\n");
+  test_ratios_dp( 3.0, 6, DGS_RROUND_UNIFORM_ONLINE);
+  test_ratios_dp( 2.0, 6, DGS_RROUND_UNIFORM_ONLINE);
+  test_ratios_dp( 4.0, 3, DGS_RROUND_UNIFORM_ONLINE);
+  test_ratios_dp(15.4, 3, DGS_RROUND_UNIFORM_ONLINE);
+  printf("\n");
+  
+  test_ratios_dp( 3.0, 6, DGS_RROUND_KARNEY);
+  test_ratios_dp( 2.0, 6, DGS_RROUND_KARNEY);
+  test_ratios_dp( 4.0, 3, DGS_RROUND_KARNEY);
+  test_ratios_dp(15.4, 3, DGS_RROUND_KARNEY);
+  printf("\n");
+
+  printf("# testing [⌊c⌋-⌈στ⌉,…, ⌊c⌋+⌈στ⌉] boundaries #\n");
+  test_uniform_boundaries_dp( 3.0, 0.0, 2, DGS_RROUND_UNIFORM_ONLINE);
+  test_uniform_boundaries_dp(10.0, 0.0, 2, DGS_RROUND_UNIFORM_ONLINE);
+  test_uniform_boundaries_dp( 3.3, 1.0, 1, DGS_RROUND_UNIFORM_ONLINE);
+  test_uniform_boundaries_dp( 2.0, 1.5, 2, DGS_RROUND_UNIFORM_ONLINE);
+  printf("\n");
+
+  printf("# testing c is center #\n");
+  test_mean_dp( 3.0, 0.0, 6, DGS_RROUND_UNIFORM_ONLINE);
+  test_mean_dp(10.0, 0.0, 6, DGS_RROUND_UNIFORM_ONLINE);
+  test_mean_dp( 3.3, 1.0, 6, DGS_RROUND_UNIFORM_ONLINE);
+  test_mean_dp( 2.0, 1.5, 6, DGS_RROUND_UNIFORM_ONLINE);
+  printf("\n");
+  
+  test_mean_dp( 3.0, 0.0, 6, DGS_RROUND_KARNEY);
+  test_mean_dp(10.0, 0.0, 6, DGS_RROUND_KARNEY);
+  test_mean_dp( 3.3, 1.0, 6, DGS_RROUND_KARNEY);
+  test_mean_dp( 2.0, 1.5, 6, DGS_RROUND_KARNEY);
+  printf("\n");
+
+  return 0;
+}


### PR DESCRIPTION
This pull request adds a new structure that we call a randomized rounder ("dgs_rround"), which is a discrete Gaussian sampler, but offers an interface that allows to pass new parameters for every sample. Two randomized rounders are implemented: simple rejection sampling (essentially a copy of the uniform+online sampler) and Karney's algorithm, which is faster than the former. The tests and benchmarks are extended accordingly (essentially duplicated). 